### PR TITLE
Add local hotkey variable to init.lua

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ In your `~/.hammerspoon/init.lua`:
 
 ```lua
 local tiling = require "hs.tiling"
+local hotkey = require "hs.hotkey"
 local mash = {"ctrl", "cmd"}
 
 hotkey.bind(mash, "c", function() tiling.cyclelayout() end)


### PR DESCRIPTION
Without this line, the hammer spoon config errors out upon starting up.
