### PR TITLE
Update syntax to adapt latest hammerspoon

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -28,7 +28,7 @@ function tiling.goToLayout(name)
 end
 
 function tiling.toggleFloat(floatfn)
-  local win = window:focusedWindow()
+  local win = window.focusedWindow()
   local id = win:id()
   excluded[id] = not excluded[id]
 
@@ -60,7 +60,7 @@ end
 function tiling.cycle(direction)
   local space = getSpace()
   local windows = space.windows
-  local win = window:focusedWindow() or windows[1]
+  local win = window.focusedWindow() or windows[1]
   local direction = direction or 1
   local currentIndex = fnutils.indexOf(windows, win)
   local layout = space.layout
@@ -86,7 +86,7 @@ end
 function tiling.promote()
   local space = getSpace()
   local windows = space.windows
-  local win = window:focusedWindow() or windows[1]
+  local win = window.focusedWindow() or windows[1]
   local i = fnutils.indexOf(windows, win)
   if not i then return end
 


### PR DESCRIPTION
Hi @dsanson 

Now `focusedWindow `is a constructor type, in stead of a method.

In [hammerspoon manual ](http://www.hammerspoon.org/docs/hs.window.html#focusedWindow) it is define like this:
```
 hs.window.focusedWindow() -> window
```

I tested on macOS 12.3.1 with `hammerspoon` Version 0.9.91 (6078), and It works well now.